### PR TITLE
restructure layers

### DIFF
--- a/src/main/g8/src/main/scala/$package$/server/HttpServer.scala
+++ b/src/main/g8/src/main/scala/$package$/server/HttpServer.scala
@@ -1,0 +1,36 @@
+package $package$.server
+
+import $package$.api
+import $package$.api.Api
+$if(add_caliban_endpoint.truthy)$
+import com.example.api.GraphQLApi
+$endif$
+import $package$.config.ApiConfig
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+$if(add_caliban_endpoint.truthy)$
+import akka.http.scaladsl.server.RouteConcatenation._
+$endif$
+import zio._
+import zio.config.Config
+
+object HttpServer {
+
+    trait Service {
+      def start: Managed[Throwable, Http.ServerBinding]
+    }
+
+    def live: ZLayer[Has[ActorSystem] with Config[ApiConfig] with Api$if(add_caliban_endpoint.truthy)$ with GraphQLApi$endif$, Nothing, HttpServer] =
+      ZLayer.fromServices[ActorSystem, ApiConfig, Api.Service$if(add_caliban_endpoint.truthy)$, api.graphql.GraphQLApi.Service$endif$, HttpServer.Service] { (sys, cfg, api$if(add_caliban_endpoint.truthy)$, gApi$endif$) =>
+        new Service {
+          implicit val system = sys
+          val start =
+            ZManaged.make(ZIO.fromFuture(_ => Http().bindAndHandle(api.routes$if(add_caliban_endpoint.truthy)$ ~ gApi.routes$endif$, cfg.host, cfg.port)))(b =>
+              ZIO.fromFuture(_ => b.unbind()).orDie
+            )
+        }
+      }
+
+    def start: ZManaged[HttpServer, Throwable, Http.ServerBinding] =
+      ZManaged.accessManaged[HttpServer](_.get.start)
+  }

--- a/src/main/g8/src/main/scala/$package$/server/package.scala
+++ b/src/main/g8/src/main/scala/$package$/server/package.scala
@@ -1,41 +1,7 @@
 package $package$
 
-import $package$.api.Api
-$if(add_caliban_endpoint.truthy)$
-import com.example.api.GraphQLApi
-$endif$
-import $package$.config.ApiConfig
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-$if(add_caliban_endpoint.truthy)$
-import akka.http.scaladsl.server.RouteConcatenation._
-$endif$
-import zio._
-import zio.config.Config
+import zio.Has
 
 package object server {
-
   type HttpServer = Has[HttpServer.Service]
-
-  object HttpServer {
-
-    trait Service {
-      def start: Managed[Throwable, Http.ServerBinding]
-    }
-
-    def live: ZLayer[Has[ActorSystem] with Config[ApiConfig] with Api$if(add_caliban_endpoint.truthy)$ with GraphQLApi$endif$, Nothing, HttpServer] =
-      ZLayer.fromServices[ActorSystem, ApiConfig, Api.Service$if(add_caliban_endpoint.truthy)$, api.graphql.GraphQLApi.Service$endif$, HttpServer.Service] { (sys, cfg, api$if(add_caliban_endpoint.truthy)$, gApi$endif$) =>
-        new Service {
-          implicit val system = sys
-          val start =
-            ZManaged.make(ZIO.fromFuture(_ => Http().bindAndHandle(api.routes$if(add_caliban_endpoint.truthy)$ ~ gApi.routes$endif$, cfg.host, cfg.port)))(b =>
-              ZIO.fromFuture(_ => b.unbind()).orDie
-            )
-        }
-      }
-
-    def start: ZManaged[HttpServer, Throwable, Http.ServerBinding] =
-      ZManaged.accessManaged[HttpServer](_.get.start)
-  }
-
 }

--- a/src/main/g8/src/main/scala/$package$/server/package.scala
+++ b/src/main/g8/src/main/scala/$package$/server/package.scala
@@ -1,0 +1,41 @@
+package $package$
+
+import $package$.api.Api
+$if(add_caliban_endpoint.truthy)$
+import com.example.api.GraphQLApi
+$endif$
+import $package$.config.ApiConfig
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+$if(add_caliban_endpoint.truthy)$
+import akka.http.scaladsl.server.RouteConcatenation._
+$endif$
+import zio._
+import zio.config.Config
+
+package object server {
+
+  type HttpServer = Has[HttpServer.Service]
+
+  object HttpServer {
+
+    trait Service {
+      def start: Managed[Throwable, Http.ServerBinding]
+    }
+
+    def live: ZLayer[Has[ActorSystem] with Config[ApiConfig] with Api$if(add_caliban_endpoint.truthy)$ with GraphQLApi$endif$, Nothing, HttpServer] =
+      ZLayer.fromServices[ActorSystem, ApiConfig, Api.Service$if(add_caliban_endpoint.truthy)$, api.graphql.GraphQLApi.Service$endif$, HttpServer.Service] { (sys, cfg, api$if(add_caliban_endpoint.truthy)$, gApi$endif$) =>
+        new Service {
+          implicit val system = sys
+          val start =
+            ZManaged.make(ZIO.fromFuture(_ => Http().bindAndHandle(api.routes$if(add_caliban_endpoint.truthy)$ ~ gApi.routes$endif$, cfg.host, cfg.port)))(b =>
+              ZIO.fromFuture(_ => b.unbind()).orDie
+            )
+        }
+      }
+
+    def start: ZManaged[HttpServer, Throwable, Http.ServerBinding] =
+      ZManaged.accessManaged[HttpServer](_.get.start)
+  }
+
+}


### PR DESCRIPTION
Refactored `Http` server into a layer. Aggregation feels more consistent now. Also this could benefit if ever introduce ZIO-ZMX as this'll allow to run two servers in parallel easily like: 
```
(HttpServer.start <&> Diagnostics.start).useForever
```
